### PR TITLE
Clean up hcache handling

### DIFF
--- a/mail-client/neomutt/metadata.xml
+++ b/mail-client/neomutt/metadata.xml
@@ -14,5 +14,8 @@
     <flag name="smime">Enable support for smime</flag>
     <flag name="tokyocabinet">Enable tokyocabinet database backend for header
       caching</flag>
+    <flag name="kyotocabinet">Enable kyotocabinet database backend for header
+      caching</flag>
+    <flag name="lmdb">Enable LMDB backend for header caching</flag>
   </use>
 </pkgmetadata>

--- a/mail-client/neomutt/neomutt-20170602.ebuild
+++ b/mail-client/neomutt/neomutt-20170602.ebuild
@@ -85,6 +85,7 @@ src_configure() {
 		"$(use_enable notmuch)"
 		"$(use_with idn)"
 		"$(use_with kerberos gss)"
+		"$(use_with sasl)"
 		"--with-$(use slang && echo slang || echo curses)=${EPREFIX}/usr"
 		"--enable-nfs-fix"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
@@ -118,14 +119,11 @@ src_configure() {
 			|| myconf+=( "--without-${hcache#*:}" )
 	done
 
-	# there's no need for gnutls, ssl or sasl without socket support
 	if use gnutls; then
 		myconf+=( "--with-gnutls" )
 	elif use ssl; then
 		myconf+=( "--with-ssl" )
 	fi
-	# not sure if this should be mutually exclusive with the other two
-	myconf+=( "$(use_with sasl)" )
 
 	if use mbox; then
 		myconf+=( "--with-mailpath=${EPREFIX}/var/spool/mail" )

--- a/mail-client/neomutt/neomutt-20170602.ebuild
+++ b/mail-client/neomutt/neomutt-20170602.ebuild
@@ -18,20 +18,20 @@ fi
 
 DESCRIPTION="Teaching an Old Dog New Tricks"
 HOMEPAGE="https://www.neomutt.org/"
-IUSE="berkdb crypt debug doc gdbm gnutls gpg idn kerberos libressl mbox nls notmuch qdbm sasl selinux slang smime ssl tokyocabinet"
+IUSE="berkdb crypt debug doc gdbm gnutls gpg idn kerberos libressl mbox nls notmuch qdbm sasl selinux slang smime ssl tokyocabinet kyotocabinet lmdb"
 SLOT="0"
 LICENSE="GPL-2"
 CDEPEND="
 	app-misc/mime-types
 	nls? ( virtual/libintl )
-	tokyocabinet?  ( dev-db/tokyocabinet )
-	!tokyocabinet? (
-		qdbm?  ( dev-db/qdbm )
-		!qdbm? (
-			gdbm?  ( sys-libs/gdbm )
-			!gdbm? ( berkdb? ( >=sys-libs/db-4:= ) )
-		)
-	)
+
+	tokyocabinet? ( dev-db/tokyocabinet )
+	qdbm? ( dev-db/qdbm )
+	gdbm? ( sys-libs/gdbm )
+	berkdb? ( >=sys-libs/db-4:= )
+	kyotocabinet? ( dev-db/kyotocabinet )
+	lmdb? ( dev-db/lmdb )
+
 	gnutls?  ( >=net-libs/gnutls-1.0.17 )
 	!gnutls? (
 		ssl? (
@@ -86,6 +86,12 @@ src_configure() {
 		"$(use_with idn)"
 		"$(use_with kerberos gss)"
 		"$(use_with sasl)"
+		"$(use_with gdbm)"
+		"$(use_with tokyocabinet)"
+		"$(use_with kyotocabinet)"
+		"$(use_with qdbm)"
+		"$(use_with berkdb bdb)"
+		"$(use_with lmdb)"
 		"--with-$(use slang && echo slang || echo curses)=${EPREFIX}/usr"
 		"--enable-nfs-fix"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
@@ -97,27 +103,6 @@ src_configure() {
 		# arrows in index view do not show when using wchar_t
 		myconf+=( "--without-wc-funcs" )
 	fi
-
-	# mutt prioritizes gdbm over bdb, so we will too.
-	# hcache feature requires at least one database is in USE.
-	local hcaches=(
-		"tokyocabinet"
-		"qdbm"
-		"gdbm"
-		"berkdb:bdb"
-	)
-	local ucache hcache lcache
-	for hcache in "${hcaches[@]}" ; do
-		if use ${hcache%%:*} ; then
-			ucache=${hcache}
-			break
-		fi
-	done
-	for hcache in "${hcaches[@]}" ; do
-		[[ ${hcache} == ${ucache} ]] \
-			&& myconf+=( "--with-${hcache#*:}" ) \
-			|| myconf+=( "--without-${hcache#*:}" )
-	done
 
 	if use gnutls; then
 		myconf+=( "--with-gnutls" )

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -85,6 +85,7 @@ src_configure() {
 		"$(use_enable notmuch)"
 		"$(use_with idn)"
 		"$(use_with kerberos gss)"
+		"$(use_with sasl)"
 		"--with-$(use slang && echo slang || echo curses)=${EPREFIX}/usr"
 		"--enable-nfs-fix"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
@@ -118,14 +119,11 @@ src_configure() {
 			|| myconf+=( "--without-${hcache#*:}" )
 	done
 
-	# there's no need for gnutls, ssl or sasl without socket support
 	if use gnutls; then
 		myconf+=( "--with-gnutls" )
 	elif use ssl; then
 		myconf+=( "--with-ssl" )
 	fi
-	# not sure if this should be mutually exclusive with the other two
-	myconf+=( "$(use_with sasl)" )
 
 	if use mbox; then
 		myconf+=( "--with-mailpath=${EPREFIX}/var/spool/mail" )

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -18,20 +18,20 @@ fi
 
 DESCRIPTION="Teaching an Old Dog New Tricks"
 HOMEPAGE="https://www.neomutt.org/"
-IUSE="berkdb crypt debug doc gdbm gnutls gpg idn kerberos libressl mbox nls notmuch qdbm sasl selinux slang smime ssl tokyocabinet"
+IUSE="berkdb crypt debug doc gdbm gnutls gpg idn kerberos libressl mbox nls notmuch qdbm sasl selinux slang smime ssl tokyocabinet kyotocabinet lmdb"
 SLOT="0"
 LICENSE="GPL-2"
 CDEPEND="
 	app-misc/mime-types
 	nls? ( virtual/libintl )
-	tokyocabinet?  ( dev-db/tokyocabinet )
-	!tokyocabinet? (
-		qdbm?  ( dev-db/qdbm )
-		!qdbm? (
-			gdbm?  ( sys-libs/gdbm )
-			!gdbm? ( berkdb? ( >=sys-libs/db-4:= ) )
-		)
-	)
+
+	tokyocabinet? ( dev-db/tokyocabinet )
+	qdbm? ( dev-db/qdbm )
+	gdbm? ( sys-libs/gdbm )
+	berkdb? ( >=sys-libs/db-4:= )
+	kyotocabinet? ( dev-db/kyotocabinet )
+	lmdb? ( dev-db/lmdb )
+
 	gnutls?  ( >=net-libs/gnutls-1.0.17 )
 	!gnutls? (
 		ssl? (
@@ -86,6 +86,12 @@ src_configure() {
 		"$(use_with idn)"
 		"$(use_with kerberos gss)"
 		"$(use_with sasl)"
+		"$(use_with gdbm)"
+		"$(use_with tokyocabinet)"
+		"$(use_with kyotocabinet)"
+		"$(use_with qdbm)"
+		"$(use_with berkdb bdb)"
+		"$(use_with lmdb)"
 		"--with-$(use slang && echo slang || echo curses)=${EPREFIX}/usr"
 		"--enable-nfs-fix"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
@@ -97,27 +103,6 @@ src_configure() {
 		# arrows in index view do not show when using wchar_t
 		myconf+=( "--without-wc-funcs" )
 	fi
-
-	# mutt prioritizes gdbm over bdb, so we will too.
-	# hcache feature requires at least one database is in USE.
-	local hcaches=(
-		"tokyocabinet"
-		"qdbm"
-		"gdbm"
-		"berkdb:bdb"
-	)
-	local ucache hcache lcache
-	for hcache in "${hcaches[@]}" ; do
-		if use ${hcache%%:*} ; then
-			ucache=${hcache}
-			break
-		fi
-	done
-	for hcache in "${hcaches[@]}" ; do
-		[[ ${hcache} == ${ucache} ]] \
-			&& myconf+=( "--with-${hcache#*:}" ) \
-			|| myconf+=( "--without-${hcache#*:}" )
-	done
 
 	if use gnutls; then
 		myconf+=( "--with-gnutls" )

--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -1,3 +1,3 @@
 # At the time of writing, BDB+NeoMutt is broken on Gentoo in general and
 # especially on multilib systems.
-berkdb
+mail-client/neomutt berkdb

--- a/profiles/use.mask
+++ b/profiles/use.mask
@@ -1,0 +1,3 @@
+# At the time of writing, BDB+NeoMutt is broken on Gentoo in general and
+# especially on multilib systems.
+berkdb


### PR DESCRIPTION
I reworked the hcache handling in the ebuilds, masked BDB (because it’s
currently broken) and while I was at it, cleaned up some leftovers.
Oh, and I added the missing backends.