### PR TITLE
Fixed an omitted wildcard character in the neomutt ebuild.

### DIFF
--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -163,5 +163,5 @@ src_install() {
 		mv "${f}" "${f%/*}/mutt.mo"
 	done
 
-	dodoc COPYRIGHT ChangeLog OPS* README*
+	dodoc COPYRIGHT ChangeLog* OPS* README*
 }


### PR DESCRIPTION
Without this character, neomutt will fail to build when running dodoc on ChangeLog.